### PR TITLE
Fix spacing issues and missing article (fixes #2, #3, #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FramePainter
-Official pytorch implementation of "FramePainter: Endowing Interactive Image Editing with  Video Diffusion Priors"
+Official pytorch implementation of "FramePainter: Endowing Interactive Image Editing with Video Diffusion Priors"
 
 [![arXiv](https://img.shields.io/badge/arXiv-2501.08225-b31b1b.svg)](https://arxiv.org/abs/2501.08225)
 ![visitors](https://visitor-badge.laobi.icu/badge?page_id=YBYBZhang/FramePainter)
@@ -9,7 +9,7 @@ https://github.com/user-attachments/assets/8e04dfce-2750-4196-8a73-b6bab833fdb1
 
 ## News
 
-* **We will release our code as soon as possible !**
+* **We will release our code as soon as possible!**
 * [01/15/2025] Paper of [FramePainter](https://arxiv.org/abs/2501.08225) released!
   
 ## Gallery
@@ -18,7 +18,7 @@ https://github.com/user-attachments/assets/8e04dfce-2750-4196-8a73-b6bab833fdb1
 <img src="intro_teaser.png" width="1080px"/> 
 </p>
 FramePainter allows users to manipulate images through intuitive sketches.
-Benefiting from powerful video diffusion priors, it not only enables intuitive and plausible edits in common scenarios, but also exhibits exceptional generalization in out-of-domain cases, e.g., transform the fish into shark-like shape.
+Benefiting from powerful video diffusion priors, it not only enables intuitive and plausible edits in common scenarios, but also exhibits exceptional generalization in out-of-domain cases, e.g., transform the fish into a shark-like shape.
 
 
 ## Acknowledgement


### PR DESCRIPTION
- Replace the double space in "with  Video Diffusion Priors" with a single space
- Remove the extra space before the exclamation mark in "possible !"
- Add the missing article "an" in "transform the fish into shark-like shape"